### PR TITLE
Release v7.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 ### Changelog:
+## v7.3.6
+#### Add
+- Check to show campaigns only when currently active
+- Check to consider events only for currently active campaigns
+- Deletion of local campaigns when remotely deleted
+#### Fix
+- Fileprovider crash on adding screenshot
+- Wrong top bar colour on campaign form pages
+
 ## v7.3.5
 #### Fix
 - Duplicate file provider among apps using Usabilla SDK

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The following functionalities will only be available on phones running Android A
 Grab the latest version using
 
 ```
-implementation 'com.usabilla.sdk:ubform:7.3.5'
+implementation 'com.usabilla.sdk:ubform:7.3.6'
 ```
 
 If you have obfuscation enabled (ProGuard/R8) and you use a version of our SDK <= 6.4.0 you need to add this line to your obfuscation configuration
@@ -304,7 +304,7 @@ The data collected content is as follows:
   "reachability": "WiFi",
   "rooted": false,
   "screenSize": "1440x2392",
-  "sdkVersion": "7.3.5",
+  "sdkVersion": "7.3.6",
   "system": "android",
   "totalMemory": "1530604",
   "totalSpace": "793488",


### PR DESCRIPTION
## v7.3.6
#### Add
- Check to show campaigns only when currently active
- Check to consider events only for currently active campaigns
- Deletion of local campaigns when remotely deleted
#### Fix
- Fileprovider crash on adding screenshot
- Wrong top bar colour on campaign form pages